### PR TITLE
force_text has been deprecated since Django 3.0, in 4.0 it has been r…

### DIFF
--- a/django_quill/widgets.py
+++ b/django_quill/widgets.py
@@ -6,7 +6,7 @@ from django.core.exceptions import ImproperlyConfigured
 from django.core.serializers.json import DjangoJSONEncoder
 from django.forms.renderers import get_default_renderer
 from django.forms.utils import flatatt
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 from django.utils.functional import Promise
 from django.utils.safestring import mark_safe
 
@@ -21,7 +21,7 @@ __all__ = (
 class LazyEncoder(DjangoJSONEncoder):
     def default(self, obj):
         if isinstance(obj, Promise):
-            return force_text(obj)
+            return force_str(obj)
         return super(LazyEncoder, self).default(obj)
 
 


### PR DESCRIPTION
…emoved: https://docs.djangoproject.com/en/4.0/releases/4.0/#features-removed-in-4-0